### PR TITLE
chore: update GitHub Actions to non-EOL versions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Run test script
       run: |


### PR DESCRIPTION
## Summary
- Update actions/checkout from v3 to v4
- Ensures compatibility with latest GitHub Actions platform
- Removes deprecated action version usage

## Test plan
- [x] GitHub Actions workflow validation passes
- [x] No breaking changes to existing functionality
- [x] Maintains compatibility with macOS automation scripts