### PR TITLE
feat: add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    assignees:
+      - "thomasvincent"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    rebase-strategy: "auto"


### PR DESCRIPTION
- Enable daily dependency scanning for GitHub Actions
- Auto-assign PRs to thomasvincent  
- Use squash merge strategy and proper labeling

This ensures the repository stays updated with the latest GitHub Actions versions for security and functionality.